### PR TITLE
refactor: create support for props and make it backward compatible

### DIFF
--- a/example/pages/index.js
+++ b/example/pages/index.js
@@ -1,82 +1,95 @@
-import { useFormatAmountInput } from 'use-format-amount-input';
-
-
+import { useFormatAmountInput } from "use-format-amount-input"
 
 export default function Index() {
+	const { amount, handleAmountChange } = useFormatAmountInput({
+		decimalPlaces: 3,
+	})
 
+	return (
+		<main>
+			<style jsx global>{`
+				body {
+					font-family: sans-serif;
+					padding: 0;
+					margin: 0;
+					background-color: #282c34;
+					min-height: 100vh;
+					display: flex;
+					align-items: center;
+					justify-content: center;
+				}
 
-  const { amount, handleAmountChange } = useFormatAmountInput();
+				.app {
+					background-color: white;
+					width: 100%;
+					width: 350px;
+					padding: 1em;
+					border-radius: 0.5em;
+					color: #282c34;
+				}
 
-  return (
-    <main>
-      <style jsx global>{`
-        body {
-          font-family: sans-serif;
-          padding: 0;
-          margin: 0;
-          background-color: #282c34;
-          min-height: 100vh;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-        }
-        
-        .app {
-          background-color: white;
-          width: 100%;
-          width: 350px;
-          padding: 1em;
-          border-radius: 0.5em;
-          color: #282c34;
-        }
+				h1 {
+					font-size: 1.8em;
+				}
 
-        h1 {
-          font-size: 1.8em;
-        }
+				input {
+					display: block;
+					width: 100%;
+					padding: 1em;
+					margin: 1em 0;
+					border: 1px solid #282c34;
+					outline: none;
+					border-radius: 0.5em;
+					box-sizing: border-box;
+					transition: border 0.5s;
+				}
 
+				input:hover {
+					border: 1px solid #61dafb;
+				}
 
-        input {
-          display: block;
-          width: 100%;
-          padding: 1em;
-          margin: 1em 0;
-          border: 1px solid #282c34;
-          outline: none;
-          border-radius: 0.5em;
-          box-sizing: border-box;
-          transition: border 0.5s;
-        }
+				footer p {
+					font-size: 0.9em;
+					margin-top: 2em;
+				}
 
-        input:hover {
-          border: 1px solid #61dafb;
-        }
+				footer p,
+				footer a {
+					color: #282c34;
+				}
+			`}</style>
 
-        footer p {
-          font-size: .9em;
-          margin-top: 2em;
-        }
+			<section className='app'>
+				<h1>Enter amount below</h1>
 
-        footer p,
-        footer a {
-          color: #282c34;
-        }
-      `}</style>
-
-      <section className="app">
-
-        <h1>Enter amount below</h1>
-
-        <form>
-          <input type="text" name="amount" onChange={handleAmountChange} value={amount} placeholder="Enter amount here" />
-        </form>
-      <footer>
-        <p>
-          Made by <a href="https://twitter.com/aremu_smog" target="_blank" rel="noreferrer">Aremu Smog</a> | <a href="https://github.com/aremu-smog/use-format-amount-input/tree/main/use-format-amount-input" target="_blank" rel="noreferrer">GitHub Repo</a>
-        </p>
-      </footer>
-      </section>
-
-    </main>
-  );
-
+				<form>
+					<input
+						type='text'
+						name='amount'
+						onChange={handleAmountChange}
+						value={amount}
+						placeholder='Enter amount here'
+					/>
+				</form>
+				<footer>
+					<p>
+						Made by{" "}
+						<a
+							href='https://twitter.com/aremu_smog'
+							target='_blank'
+							rel='noreferrer'>
+							Aremu Smog
+						</a>{" "}
+						|{" "}
+						<a
+							href='https://github.com/aremu-smog/use-format-amount-input/tree/main/use-format-amount-input'
+							target='_blank'
+							rel='noreferrer'>
+							GitHub Repo
+						</a>
+					</p>
+				</footer>
+			</section>
+		</main>
+	)
 }

--- a/use-format-amount-input/package.json
+++ b/use-format-amount-input/package.json
@@ -1,40 +1,40 @@
 {
-  "name": "use-format-amount-input",
-  "version": "0.2.0",
-  "description": "Format price, amount input in react",
-  "author": {
-    "name": "Aremu Smog",
-    "email": "aremuoluwagbamila@gmail.com",
-    "url": "https://twitter.com/aremu_smog"
-  },
-  "keywords": [
-    "react",
-    "hooks",
-    "react-hooks",
-    "format-input"
-  ],
-  "main": "index.js",
-  "scripts": {
-    "build": "babel src --out-dir .",
-    "bump": "npm version",
-    "example": "cd example && yarn install && yarn package",
-    "prepublishOnly": "yarn build",
-    "watch": "nodemon --watch src --exec \"yarn build\""
-  },
-  "license": "MIT",
-  "devDependencies": {},
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/aremu-smog/use-format-amount-input"
-  },
-  "bugs": {
-    "url": "https://github.com/aremu-smog/use-format-amount-input/issues"
-  },
-  "dependencies": {
-    "@babel/cli": "^7.14.8",
-    "@babel/core": "^7.15.0",
-    "@babel/preset-env": "^7.15.0",
-    "@babel/preset-react": "^7.14.5",
-    "nodemon": "^2.0.12"
-  }
+	"name": "use-format-amount-input",
+	"version": "0.2.1",
+	"description": "Format price, amount input in react",
+	"author": {
+		"name": "Aremu Smog",
+		"email": "aremuoluwagbamila@gmail.com",
+		"url": "https://twitter.com/aremu_smog"
+	},
+	"keywords": [
+		"react",
+		"hooks",
+		"react-hooks",
+		"format-input"
+	],
+	"main": "index.js",
+	"scripts": {
+		"build": "babel src --out-dir .",
+		"bump": "npm version",
+		"example": "cd example && yarn install && yarn package",
+		"prepublishOnly": "yarn build",
+		"watch": "nodemon --watch src --exec \"yarn build\""
+	},
+	"license": "MIT",
+	"devDependencies": {},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aremu-smog/use-format-amount-input"
+	},
+	"bugs": {
+		"url": "https://github.com/aremu-smog/use-format-amount-input/issues"
+	},
+	"dependencies": {
+		"@babel/cli": "^7.14.8",
+		"@babel/core": "^7.15.0",
+		"@babel/preset-env": "^7.15.0",
+		"@babel/preset-react": "^7.14.5",
+		"nodemon": "^2.0.12"
+	}
 }

--- a/use-format-amount-input/src/useFormatAmountInput.js
+++ b/use-format-amount-input/src/useFormatAmountInput.js
@@ -1,62 +1,77 @@
-import {useState} from "react"
+import { useState } from "react"
 
-export default function useFormatAmountInput (decimalPlaces = 0) {
-  const [amount, setAmount] = useState("")
+export default function useFormatAmountInput(props) {
+	// This check was made to ensure backwards compatibility with accpeting only the decimal place as a parameter.
+	let decimalPlaces = typeof props === "number" ? props : props?.decimalPlaces
 
-  const handleAmountChange = (e) =>{
-    const keyPressed = e.nativeEvent.data
+	// Destructure other properties here
 
-    
-    const amountValue = e.target.value.trim()
+	const [amount, setAmount] = useState("")
 
-    
-    const cursorPosition = e.target.selectionStart
+	const handleAmountChange = e => {
+		const keyPressed = e.nativeEvent.data
+
+		const amountValue = e.target.value.trim()
+
+		const cursorPosition = e.target.selectionStart
 		const keyPattern = /\d/
 
-		if (keyPattern.test(Number(keyPressed)) || (keyPressed.includes(".") && !amount.includes("."))) {
+		if (
+			keyPattern.test(Number(keyPressed)) ||
+			(keyPressed.includes(".") && !amount.includes("."))
+		) {
 			const strippedAmount = amountValue.replaceAll(",", "")
 
-      const amountValueArray = strippedAmount.split(".")
+			const amountValueArray = strippedAmount.split(".")
 
-      const leftHandside = amountValueArray[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",")
-      const rightHandside = amountValueArray[1]
+			const leftHandside = amountValueArray[0].replace(
+				/\B(?=(\d{3})+(?!\d))/g,
+				","
+			)
+			const rightHandside = amountValueArray[1]
 
-      if(decimalPlaces && rightHandside?.length > decimalPlaces){
-        return
-      }
+			if (decimalPlaces && rightHandside?.length > decimalPlaces) {
+				return
+			}
 
-      let value = leftHandside
+			let value = leftHandside
 
-      if(amountValueArray.length === 2){
-        value += `.${rightHandside}`
-      }
-		
+			if (amountValueArray.length === 2) {
+				value += `.${rightHandside}`
+			}
+
 			setAmount(value)
-		}else{
-      return
-    }
+		} else {
+			return
+		}
 
-    setTimeout(()=>{
-      const targetValue = e.target.value
-      const hasCommas = (/,/g).test(targetValue)
-      const inputType = e.nativeEvent.inputType
+		setTimeout(() => {
+			const targetValue = e.target.value
+			const hasCommas = /,/g.test(targetValue)
+			const inputType = e.nativeEvent.inputType
 
-      const isDeleting = inputType === "deleteContentBackward" || inputType === "deleteContentForward" || inputType === "deleteContent" || inputType === "deleteByCut"
+			const isDeleting =
+				inputType === "deleteContentBackward" ||
+				inputType === "deleteContentForward" ||
+				inputType === "deleteContent" ||
+				inputType === "deleteByCut"
 
- 
-      if(hasCommas && ((cursorPosition + 1)  === targetValue.length) && !isDeleting){   
-        e.target.selectionStart = cursorPosition  + 1
-        e.target.selectionEnd = cursorPosition  + 1
-      }else{
-        e.target.selectionStart = cursorPosition  
-        e.target.selectionEnd = cursorPosition  
-      }
-    },0)
-  }
+			if (
+				hasCommas &&
+				cursorPosition + 1 === targetValue.length &&
+				!isDeleting
+			) {
+				e.target.selectionStart = cursorPosition + 1
+				e.target.selectionEnd = cursorPosition + 1
+			} else {
+				e.target.selectionStart = cursorPosition
+				e.target.selectionEnd = cursorPosition
+			}
+		}, 0)
+	}
 
-
-  return {
-    amount,
-    handleAmountChange
-  };
+	return {
+		amount,
+		handleAmountChange,
+	}
 }


### PR DESCRIPTION
## Objective(s)

Right now, the `hook` only accepts a parameter which represents the number of decimal places allowed. The goal is to ensure that an object can be passed to the hook while creating backward compatibility in case of old users who are still passing only the number of `decimal places`

## Description of Change

Kindly see file changes

## Operations Impact

N/A

## Quality Assurance
Install the package and assert that:
- Passing only a single value say 2,3 - the number of decimal places doesn't exceed this
- Passing an object with the property `decimalPlaces`, it's value determines the number of decimal places the user is allowed to enter


## Priority of Change
Normal