### PR TITLE
Feat: stripped amount

### DIFF
--- a/example/pages/index.js
+++ b/example/pages/index.js
@@ -1,7 +1,7 @@
 import { useFormatAmountInput } from "use-format-amount-input"
 
 export default function Index() {
-	const { amount, handleAmountChange } = useFormatAmountInput({
+	const { amount, strippedAmount, handleAmountChange } = useFormatAmountInput({
 		decimalPlaces: 3,
 	})
 
@@ -71,6 +71,9 @@ export default function Index() {
 						placeholder='Enter amount here'
 					/>
 				</form>
+				<p>
+					<small>Stripped amount: {strippedAmount}</small>
+				</p>
 				<footer>
 					<p>
 						Made by{" "}

--- a/use-format-amount-input/src/useFormatAmountInput.js
+++ b/use-format-amount-input/src/useFormatAmountInput.js
@@ -8,6 +8,8 @@ export default function useFormatAmountInput(props) {
 
 	const [amount, setAmount] = useState("")
 
+	const separator = ","
+
 	const handleAmountChange = e => {
 		const keyPressed = e.nativeEvent.data
 
@@ -20,13 +22,13 @@ export default function useFormatAmountInput(props) {
 			keyPattern.test(Number(keyPressed)) ||
 			(keyPressed.includes(".") && !amount.includes("."))
 		) {
-			const strippedAmount = amountValue.replaceAll(",", "")
+			const strippedAmount = amountValue.replaceAll(separator, "")
 
 			const amountValueArray = strippedAmount.split(".")
 
 			const leftHandside = amountValueArray[0].replace(
 				/\B(?=(\d{3})+(?!\d))/g,
-				","
+				separator
 			)
 			const rightHandside = amountValueArray[1]
 
@@ -47,7 +49,7 @@ export default function useFormatAmountInput(props) {
 
 		setTimeout(() => {
 			const targetValue = e.target.value
-			const hasCommas = /,/g.test(targetValue)
+			const hasCommas = targetValue.includes(separator)
 			const inputType = e.nativeEvent.inputType
 
 			const isDeleting =

--- a/use-format-amount-input/src/useFormatAmountInput.js
+++ b/use-format-amount-input/src/useFormatAmountInput.js
@@ -72,8 +72,11 @@ export default function useFormatAmountInput(props) {
 		}, 0)
 	}
 
+	const strippedAmount = amount.replaceAll(separator, "")
+
 	return {
 		amount,
 		handleAmountChange,
+		strippedAmount,
 	}
 }


### PR DESCRIPTION
## Objective

Right now, the user only has access to the `delimited` amount value say `1,000`. Most APIs would not support this out of the box and would require the developer to `strip` the `delimiter/separator` which is not bad but can quickly become boring if you have multiple fields using this. The fix? Strip the amount and return it to the user.

This PR fixes #2 

## Description of Change
- Made a refactor and extracted the `,` into a variable 
- Added an output for `strippedAmount` in example

## Operations Impact

N/A

## Priority of Change

High