### PR TITLE
Feat custom separator

### DIFF
--- a/example/pages/index.js
+++ b/example/pages/index.js
@@ -3,6 +3,7 @@ import { useFormatAmountInput } from "use-format-amount-input"
 export default function Index() {
 	const { amount, strippedAmount, handleAmountChange } = useFormatAmountInput({
 		decimalPlaces: 3,
+		separator: ".",
 	})
 
 	return (

--- a/use-format-amount-input/package.json
+++ b/use-format-amount-input/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "use-format-amount-input",
-	"version": "0.2.2",
+	"version": "0.2.5",
 	"description": "Format price, amount input in react",
 	"author": {
 		"name": "Aremu Smog",

--- a/use-format-amount-input/src/useFormatAmountInput.js
+++ b/use-format-amount-input/src/useFormatAmountInput.js
@@ -1,14 +1,17 @@
 import { useState } from "react"
 
-export default function useFormatAmountInput(props) {
+export default function useFormatAmountInput({ separator = ",", ...props }) {
 	// This check was made to ensure backwards compatibility with accpeting only the decimal place as a parameter.
 	let decimalPlaces = typeof props === "number" ? props : props?.decimalPlaces
 
-	// Destructure other properties here
-
 	const [amount, setAmount] = useState("")
 
-	const separator = ","
+	if (separator === ".") {
+		separator = ","
+		console.warn(
+			"To avoid confusion with decimal places, '.' cannot be used as a separator"
+		)
+	}
 
 	const handleAmountChange = e => {
 		const keyPressed = e.nativeEvent.data


### PR DESCRIPTION
## Objective

- Allow support for custom separators🚀🥳

## Description of change

- `separator` was added as a prop and a check was made to ensure that `.` cannot be passed as a delimiter to avoid confusion with the decimal point


## Priority of Change

High